### PR TITLE
Add knexfile.js migrations.lockTableName option

### DIFF
--- a/src/migrate/index.js
+++ b/src/migrate/index.js
@@ -152,7 +152,7 @@ export default class Migrator {
   }
 
   _getLockTableName() {
-    return this.config.tableName + '_lock';
+    return this.config.lockTableName || this.config.tableName + '_lock';
   }
 
   _isLocked(trx) {


### PR DESCRIPTION
Add the ability to name the lock table via migrations.lockTableName config.  Currently a "_lock" suffix is appended to the tableName.